### PR TITLE
Ensure date/time format is maintained when determining home

### DIFF
--- a/src/features/phone_locations/barnett/library/SigLocs.R
+++ b/src/features/phone_locations/barnett/library/SigLocs.R
@@ -45,7 +45,7 @@ function(mobmat,obj,CENTERRAD=125,MINPAUSETIME=600,tz=""){
   }
   #Determine which is home (where is the night spent)
   for(i in 1:length(obj$ID2)){
-    xx=as.POSIXct((mobmat[obj$ID2[i],7]+mobmat[obj$ID2[i],4])/2,tz=tz,origin="1970-01-01")
+    xx=format(as.POSIXct((mobmat[obj$ID2[i],7]+mobmat[obj$ID2[i],4])/2,tz=tz,origin="1970-01-01"), "%Y-%m-%d %H:%M:%S")
     hourofday = as.numeric(strsplit(strsplit(as.character(xx),":")[[1]][1]," ")[[1]][2])
     if(hourofday>=21 || hourofday<6){
       for(j in 1:nrowfc){


### PR DESCRIPTION
With reference to the issue #156 I raised yesterday, please find below a small fix!

Within the 'determine which is home' for loop, 'xx' is the midpoint of two datetime objects. When the midpoint is calculated to be midnight, only the date is returned. This can be replicated with:

mydates <- as.POSIXct("2018-01-01 00:00:00", tz = "UTC")
mydates
[1] "2018-01-01 UTC"

This results in 'hourofday' being NA as an hour cannot be found. By adding the suggested format wrapper, the time is maintained and 'hourofday' can be determined. It can then successfully be applied to the if-statement within the loop.

mydates <- format(as.POSIXct("2018-01-01 00:00:00", tz = "UTC"), "%Y-%m-%d %H:%M:%S")
mydates
[1] "2018-01-01 00:00:00"