### PR TITLE
Avoid NA problem in barnett location evaluation

### DIFF
--- a/src/features/phone_locations/barnett/daily_features.R
+++ b/src/features/phone_locations/barnett/daily_features.R
@@ -25,12 +25,11 @@ barnett_daily_features <- function(snakemake){
   datetime_end_regex = "[0-9]{4}[\\-|\\/][0-9]{2}[\\-|\\/][0-9]{2} 23:59:59"
   location <- location %>% 
     mutate(is_daily = str_detect(assigned_segments, paste0(".*#", datetime_start_regex, ",", datetime_end_regex, ".*")))
-  
-  if(nrow(segment_labels) == 0 || nrow(location) == 0 || all(location$is_daily == FALSE) || (max(location$timestamp) - min(location$timestamp) < 86400000)){
-    warning("Barnett's location features cannot be computed for data or time segments that do not span one or more entire days (00:00:00 to 23:59:59). Values below point to the problem:",
-            "\nLocation data rows within a daily time segment: ", nrow(filter(location, is_daily)),
-            "\nLocation data time span in days: ", round((max(location$timestamp) - min(location$timestamp)) / 86400000, 2)
-            )
+
+  does_not_span = nrow(segment_labels) == 0 || nrow(location) == 0 || all(location$is_daily == FALSE) || (max(location$timestamp) - min(location$timestamp) < 86400000)
+
+  if(is.na(does_not_span) || does_not_span){
+    message("Barnett's location features cannot be computed for data or time segments that do not span one or more entire days (00:00:00 to 23:59:59). Values below point to the problem:")
     location_features <- create_empty_file()  
   } else{
     # Count how many minutes of data we use to get location features. Some minutes have multiple fused rows

--- a/src/features/phone_locations/barnett/daily_features.R
+++ b/src/features/phone_locations/barnett/daily_features.R
@@ -29,7 +29,10 @@ barnett_daily_features <- function(snakemake){
   does_not_span = nrow(segment_labels) == 0 || nrow(location) == 0 || all(location$is_daily == FALSE) || (max(location$timestamp) - min(location$timestamp) < 86400000)
 
   if(is.na(does_not_span) || does_not_span){
-    message("Barnett's location features cannot be computed for data or time segments that do not span one or more entire days (00:00:00 to 23:59:59). Values below point to the problem:")
+      warning("Barnett's location features cannot be computed for data or time segments that do not span one or more entire days (00:00:00 to 23:59:59). Values below point to the problem:",
+            "\nLocation data rows within a daily time segment: ", nrow(filter(location, is_daily)),
+            "\nLocation data time span in days: ", round((max(location$timestamp) - min(location$timestamp)) / 86400000, 2)
+            )
     location_features <- create_empty_file()  
   } else{
     # Count how many minutes of data we use to get location features. Some minutes have multiple fused rows


### PR DESCRIPTION
Avoid an issue where occasional weird data causes the condition being evaluated in the if statement to be NA, which R does not like.

```
Error in if ((nrow(segment_labels) == 0 || nrow(location) == 0 || all(location$is_daily ==  : 
missing value where TRUE/FALSE needed
Calls: barnett_daily_features
Execution halted
[Sat Jan 15 20:12:44 2022]
Error in rule phone_locations_barnett_daily_features:
    jobid: 143
    output: data/interim/73KY/phone_locations_barnett_daily.csv
```

