### PR TITLE
Optimize memory usage in readable_datetime.R script

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -1,6 +1,7 @@
 # Change Log
 ## v1.9.0
 - Upgrade generics package
+- Optimize memory usage in readable_datetime.R script
 ## v1.8.0
 - Add data stream for AWARE Micro server
 - Fix the NA bug in PHONE_LOCATIONS BARNETT provider

--- a/rules/models.smk
+++ b/rules/models.smk
@@ -40,7 +40,8 @@ rule target_readable_datetime:
         time_segments_type = config["TIME_SEGMENTS"]["TYPE"],
         include_past_periodic_segments = config["TIME_SEGMENTS"]["INCLUDE_PAST_PERIODIC_SEGMENTS"]
     output:
-        "data/raw/{pid}/participant_target_with_datetime.csv"
+        target_with_datetime = "data/raw/{pid}/participant_target_with_datetime.csv",
+        flag_file = touch("data/raw/{pid}/participant_target_with_datetime.done")
     script:
         "../src/data/datetime/readable_datetime.R"
 

--- a/rules/preprocessing.smk
+++ b/rules/preprocessing.smk
@@ -49,7 +49,8 @@ rule phone_readable_datetime:
         time_segments_type = config["TIME_SEGMENTS"]["TYPE"],
         include_past_periodic_segments = config["TIME_SEGMENTS"]["INCLUDE_PAST_PERIODIC_SEGMENTS"]
     output:
-        "data/raw/{pid}/phone_{sensor}_with_datetime.csv"
+        sensor_with_datetime = "data/raw/{pid}/phone_{sensor}_with_datetime.csv",
+        flag_file = touch("data/raw/{pid}/phone_{sensor}_with_datetime.done")
     script:
         "../src/data/datetime/readable_datetime.R"
 
@@ -76,7 +77,8 @@ rule phone_yielded_timestamps_with_datetime:
         time_segments_type = config["TIME_SEGMENTS"]["TYPE"],
         include_past_periodic_segments = config["TIME_SEGMENTS"]["INCLUDE_PAST_PERIODIC_SEGMENTS"]
     output:
-        "data/interim/{pid}/phone_yielded_timestamps_with_datetime.csv"
+        timestamps_with_datetime = "data/interim/{pid}/phone_yielded_timestamps_with_datetime.csv",
+        flag_file = touch("data/interim/{pid}/phone_yielded_timestamps_with_datetime.done")
     script:
         "../src/data/datetime/readable_datetime.R"
 
@@ -118,7 +120,8 @@ rule phone_locations_processed_with_datetime:
         time_segments_type = config["TIME_SEGMENTS"]["TYPE"],
         include_past_periodic_segments = config["TIME_SEGMENTS"]["INCLUDE_PAST_PERIODIC_SEGMENTS"]
     output:
-        "data/interim/{pid}/phone_locations_processed_with_datetime.csv"
+        locations_processed_with_datetime = "data/interim/{pid}/phone_locations_processed_with_datetime.csv",
+        flag_file = touch("data/interim/{pid}/phone_locations_processed_with_datetime.done")
     script:
         "../src/data/datetime/readable_datetime.R"
 
@@ -143,7 +146,8 @@ rule resample_episodes_with_datetime:
         time_segments_type = config["TIME_SEGMENTS"]["TYPE"],
         include_past_periodic_segments = config["TIME_SEGMENTS"]["INCLUDE_PAST_PERIODIC_SEGMENTS"]
     output:
-        "data/interim/{pid}/{sensor}_episodes_resampled_with_datetime.csv"
+        sensor_episodes_resampled_with_datetime = "data/interim/{pid}/{sensor}_episodes_resampled_with_datetime.csv",
+        flag_file = touch("data/interim/{pid}/{sensor}_episodes_resampled_with_datetime.done")
     script:
         "../src/data/datetime/readable_datetime.R"
 
@@ -189,7 +193,8 @@ rule fitbit_readable_datetime:
         time_segments_type = config["TIME_SEGMENTS"]["TYPE"],
         include_past_periodic_segments = config["TIME_SEGMENTS"]["INCLUDE_PAST_PERIODIC_SEGMENTS"]
     output:
-        "data/raw/{pid}/fitbit_{sensor}_with_datetime.csv"
+        sensor_with_datetime = "data/raw/{pid}/fitbit_{sensor}_with_datetime.csv",
+        flag_file = touch("data/raw/{pid}/fitbit_{sensor}_with_datetime.done")
     script:
         "../src/data/datetime/readable_datetime.R"
 
@@ -217,6 +222,7 @@ rule empatica_readable_datetime:
         time_segments_type = config["TIME_SEGMENTS"]["TYPE"],
         include_past_periodic_segments = config["TIME_SEGMENTS"]["INCLUDE_PAST_PERIODIC_SEGMENTS"]
     output:
-        "data/raw/{pid}/empatica_{sensor}_with_datetime.csv"
+        sensor_with_datetime = "data/raw/{pid}/empatica_{sensor}_with_datetime.csv",
+        flag_file = touch("data/raw/{pid}/empatica_{sensor}_with_datetime.done")
     script:
         "../src/data/datetime/readable_datetime.R"

--- a/src/data/datetime/readable_datetime.R
+++ b/src/data/datetime/readable_datetime.R
@@ -105,14 +105,13 @@ process_by_chunks <- function(timezone_parameters, device_type, pid, participant
   function(x, pos){
 
     output_is_empty <<- FALSE
-    input <- x %>% arrange(timestamp)
 
     if(timezone_parameters$TYPE == "SINGLE"){
-      output <- input %>% mutate(local_timezone = timezone_parameters$SINGLE$TZCODE)
+      output <- x %>% mutate(local_timezone = timezone_parameters$SINGLE$TZCODE)
       most_common_tz <- timezone_parameters$SINGLE$TZCODE
     }
     else if(timezone_parameters$TYPE == "MULTIPLE"){
-      output <- multiple_time_zone_assignment(input, timezone_parameters, device_type, pid, participant_file)
+      output <- multiple_time_zone_assignment(x, timezone_parameters, device_type, pid, participant_file)
       most_common_tz <- get_participant_most_common_tz(timezone_parameters$MULTIPLE$TZCODES_FILE, participant_file) # in assign_to_multiple_timezones.R
     }
 

--- a/src/data/datetime/readable_datetime.R
+++ b/src/data/datetime/readable_datetime.R
@@ -99,8 +99,36 @@ filter_wanted_dates <- function(output, participant_file, device_type){
 
   return(output)
 }
+
+process_by_chunks <- function(timezone_parameters, device_type, pid, participant_file, time_segments, time_segments_type, include_past_periodic_segments, output_file_path){
+  
+  function(x, pos){
+
+    output_is_empty <<- FALSE
+    input <- x %>% arrange(timestamp)
+
+    if(timezone_parameters$TYPE == "SINGLE"){
+      output <- input %>% mutate(local_timezone = timezone_parameters$SINGLE$TZCODE)
+      most_common_tz <- timezone_parameters$SINGLE$TZCODE
+    }
+    else if(timezone_parameters$TYPE == "MULTIPLE"){
+      output <- multiple_time_zone_assignment(input, timezone_parameters, device_type, pid, participant_file)
+      most_common_tz <- get_participant_most_common_tz(timezone_parameters$MULTIPLE$TZCODES_FILE, participant_file) # in assign_to_multiple_timezones.R
+    }
+
+    output %<>%  
+      create_mising_temporal_column(device_type)  %>% 
+      split_local_date_time() %>% 
+      assign_to_time_segment(time_segments, time_segments_type, include_past_periodic_segments, most_common_tz) %>% 
+      filter_wanted_dates(participant_file, device_type) %>% 
+      arrange(timestamp)
+    
+    output %>% write_csv(output_file_path, append=ifelse(pos > 1, T, F))
+  }
+}
+
 readable_datetime <- function(){
-  input <- read.csv(snakemake@input[["sensor_input"]]) %>% arrange(timestamp)
+
   time_segments <- read.csv(snakemake@input[["time_segments"]])
   participant_file <- snakemake@input[["pid_file"]]
   device_type <- snakemake@params[["device_type"]]
@@ -108,26 +136,25 @@ readable_datetime <- function(){
   pid <- snakemake@params[["pid"]]
   time_segments_type <- snakemake@params[["time_segments_type"]]
   include_past_periodic_segments <- snakemake@params[["include_past_periodic_segments"]]
+  output_file_path <- snakemake@output[[1]]
 
   validate_user_timezones(timezone_parameters)
+
+  output_is_empty <<- TRUE
+  read_csv_chunked(snakemake@input[["sensor_input"]], 
+                  callback=DataFrameCallback$new(process_by_chunks(timezone_parameters, device_type, pid, participant_file, time_segments, time_segments_type, include_past_periodic_segments, output_file_path)), 
+                  chunk_size=10000,
+                  col_names=TRUE,
+                  col_types=cols(local_date_time = col_character(),
+                                 local_start_date_time = col_character(),
+                                 local_end_date_time = col_character()),)
   
-  if(timezone_parameters$TYPE == "SINGLE"){
-    output <- input %>% mutate(local_timezone = timezone_parameters$SINGLE$TZCODE)
-    most_common_tz <- timezone_parameters$SINGLE$TZCODE
-  }
-  else if(timezone_parameters$TYPE == "MULTIPLE"){
-    output <- multiple_time_zone_assignment(input, timezone_parameters, device_type, pid, participant_file)
-    most_common_tz <- get_participant_most_common_tz(timezone_parameters$MULTIPLE$TZCODES_FILE, participant_file) # in assign_to_multiple_timezones.R
+  if(output_is_empty){
+    column_names <- c("local_timezone", colnames(read.csv(snakemake@input[["sensor_input"]])), "local_date", "local_time", "local_hour", "local_minute", "assigned_segments")
+    output <- setNames(data.frame(matrix(nrow=0, ncol=length(column_names))), column_names)
+    output %>% write_csv(output_file_path, append=FALSE)
   }
 
-  output  %<>%  
-    create_mising_temporal_column(device_type)  %>% 
-    split_local_date_time() %>% 
-    assign_to_time_segment(time_segments, time_segments_type, include_past_periodic_segments, most_common_tz) %>% 
-    filter_wanted_dates(participant_file, device_type) %>% 
-    arrange(timestamp)
-
-  write_csv(output, snakemake@output[[1]])
 }
 
 readable_datetime()

--- a/src/data/datetime/readable_datetime.R
+++ b/src/data/datetime/readable_datetime.R
@@ -146,7 +146,8 @@ readable_datetime <- function(){
                   col_names=TRUE,
                   col_types=cols(local_date_time = col_character(),
                                  local_start_date_time = col_character(),
-                                 local_end_date_time = col_character()),)
+                                 local_end_date_time = col_character()),
+                  trim_ws=FALSE)
   
   if(output_is_empty){
     column_names <- c("local_timezone", colnames(read.csv(snakemake@input[["sensor_input"]])), "local_date", "local_time", "local_hour", "local_minute", "assigned_segments")


### PR DESCRIPTION
Hi @JulioV, I updated our `readable_datetime.R` script to reduce memory usage. Previous script requires a very large memory while processing a large table (e.g. accelerometer data). Instead of loading the whole raw CSV file into memory, the updated script will only load and process a file in chunks (process 10k rows per time).

Besides reading a file in chunks, there are two main updates in `readable_datetime.R` script:
1. Sorting by timestamps column is discarded as it is done while pulling phone/wearable data.
2. Adding a flag file to output. Since a file is processed (read, add date time, and write) in chunks, a file named **_with_datetime.csv** will be generated at the first chunk and kept adding new rows in the rest chunks.