### PR TITLE
Bugfix - Improper PANDAS column type

### DIFF
--- a/src/features/phone_keyboard/rapids/main.py
+++ b/src/features/phone_keyboard/rapids/main.py
@@ -3,7 +3,7 @@ import numpy as np
 
 def rapids_features(sensor_data_files, time_segment, provider, filter_data_by_segment, *args, **kwargs):
 
-    keyboard_data = pd.read_csv(sensor_data_files["sensor_data"])
+    keyboard_data = pd.read_csv(sensor_data_files["sensor_data"], dtype={"current_text":object, "before_text":object})
     requested_features = provider["FEATURES"]
 
     # name of the features this function can compute


### PR DESCRIPTION
src/features/phone_keyboard/rapids:
	There was an issue with the keyboard data where if the “before_text” column consisted of only “nothing” or numeric values (including NA - “not a number”), it would default that column to numeric instead of string.  This change specifically sets the “before_text” and “current_text” columns to text when creating the pandas dataframe so the string processing later on in the file doesn’t cause the run to crash when it tries to do the “str” vector operation (Line 27) on an incompatible column type.
	

	