### PR TITLE
Update renv.lock

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -289,13 +289,6 @@
       "Repository": "CRAN",
       "Hash": "dbd1387c025b07f62da3334942176e14"
     },
-    "cpp11": {
-      "Package": "cpp11",
-      "Version": "0.2.4",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "ba66e5a750d39067d888aa7af797fed2"
-    },
     "crayon": {
       "Package": "crayon",
       "Version": "1.3.4",
@@ -989,13 +982,6 @@
       "Repository": "CRAN",
       "Hash": "7d597f982ee6263716b6a2f28efd29fa"
     },
-    "rlang": {
-      "Package": "rlang",
-      "Version": "1.0.2",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "599df23c40a4fce9c7b4764f28c37857"
-    },
     "rmarkdown": {
       "Package": "rmarkdown",
       "Version": "2.6",
@@ -1135,13 +1121,6 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "c40b2d5824d829190f4b825f4496dfae"
-    },
-    "tidyselect": {
-      "Package": "tidyselect",
-      "Version": "1.1.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "6ea435c354e8448819627cf686f66e0a"
     },
     "tidyverse": {
       "Package": "tidyverse",


### PR DESCRIPTION
@ChinW97 whenever you have a chance can you squash & merge to `develop` and release `1.9.1` with this commit please?

It fixes a library conflict that broke RAPIDS installation. 