### PR TITLE
Fix bug that resampled rows with columns out of order

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -3,6 +3,7 @@
 - Add mutation script to fix character encoding of application_name column in phone applications foreground data  
 - Fix discrepancies between computed episode and event features in PHONE_APPLICATIONS_FOREGROUND RAPIDS provider
 - Upgrade cli, lifecycle, lubridate, pillar, and vctrs R packages
+- Fix bug that scrambled the column order of resampled episodes when processng multiple time zones and some data fell outside those timezone periods
 ## v1.9.1
 - It fixes a library conflict that broke RAPIDS installation
 ## v1.9.0

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -410,6 +410,7 @@ Parameters for `[TIMEZONE]`
 
     - A screen row sensed at `1587533333333` will be assigned to `America/New_York` because it falls within Interval 1
     - A screen row sensed at `1587400000000` will be discarded because it was logged outside any interval.
+    - **Important** any sensor data that cannot be assigned to a row will be discarded and you will see a warning. To avoid this, add enough time zone intervals. Remember you can set **timestamp** to 0 to avoid having to set an initial timestamp for every device id; see below `What happens if participant X lives in Los Angeles but participant Y lives in Amsterdam and they both stayed there during my study?`
 
 ??? note "Can I get the `TZCODES_FILE` from the time zone table collected automatically by the AWARE app?"
     Sure. You can put your timezone table (`timezone.csv`) collected by the AWARE app under `data/external` folder and run:

--- a/src/data/datetime/assign_to_multiple_timezones.R
+++ b/src/data/datetime/assign_to_multiple_timezones.R
@@ -48,6 +48,19 @@ assign_tz_code <- function(data, device_id, tz_codes, device_type){
   if(column == "local_date_time")
     data$local_date_time <- format(data$local_date_time, format="%Y-%m-%d %H:%M:%S")
 
+  if(any(is.na(data$local_timezone))){
+    data_without_timezones <- data %>% filter(is.na(local_timezone))
+    warning(glue("We are discarding data for device {device_id} because some rows could not be assigned to a timezone. 
+                    This happens because the timezones in TZCODES_FILE are not covering the total period this device was sensing data. 
+                    You have two possible fixes
+                    - A) Add another timezone entry to TZCODES_FILE that covers the missing period from {min(data_without_timezones[[column]])} to {max(data_without_timezones[[column]])}.
+                          Note there will be multiple chunks because we read the sensor data in batches but you could combine the suggested individual missing periods into a single one. 
+                    - B) Assign this device id to a single timezone for the entire duration of the study. 
+                          To do this, in TZCODES_FILE, replace any timezones for {device_id} with following line:
+                              {device_id},{time_zone},0 \n\n
+                  "))
+  }
+
   return(data %>% filter(!is.na(local_timezone)))
   
 }

--- a/src/data/datetime/readable_datetime.R
+++ b/src/data/datetime/readable_datetime.R
@@ -52,7 +52,7 @@ create_mising_temporal_column <- function(data, device_type){
   if(device_type == "fitbit" && all(data$timestamp == 0) && "local_date_time" %in% colnames(data)){
       # For fibit we infere timestamp from Fitbit's local date time only right after pulling it
       if(nrow(data) == 0)
-        return(data %>% mutate(timestamp = NA_real_))
+        return(data %>% mutate(timestamp = NA_real_) %>% relocate(local_timezone)) # move local_timezone to the beginning of df to match column positions when data is not empty (group > nest)
       if(any(is.na(parse_date_time(data$local_date_time, orders= c("%Y/%m/%d %H:%M:%S","%Y-%m-%d %H:%M:%S"), exact=T))))
         stop("One or more values in the local_date_time column do not have the expected format: yyyy-mm-dd hh:mm:ss or yyyy/mm/dd hh:mm:ss")
       return(data %>% 
@@ -66,7 +66,7 @@ create_mising_temporal_column <- function(data, device_type){
     } else {
       # For the rest of devices we infere local date time from timestamp
       if(nrow(data) == 0)
-        return(data %>% mutate(local_date_time = NA_character_))
+        return(data %>% mutate(local_date_time = NA_character_) %>% relocate(local_timezone)) # move local_timezone to the beginning of df to match column positions when data is not empty (group > nest)
       return(data %>% 
           group_by(local_timezone) %>% 
           nest() %>% 


### PR DESCRIPTION
This PR fixes https://github.com/carissalow/rapids/issues/197. We also 

- Print a warning when rows cannot be assigned to a tz and so are discarded
- Update docs

The bug:

- readable_datetime process data in chunks 
- the problem ocurrred when processing data with multiple time zones and some of those rows of data could not be assigned to a time zone
- in this case we would output  columns in a different order compared to when rows were assigned to a time zone. 