### PR TITLE
Specify R version in tests workflow & Dockerfile

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,7 @@ jobs:
           # sudo apt install libxml2-dev
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
           sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/' 
-          sudo apt install r-base
+          sudo apt install -y --allow-downgrades r-base-core=4.2.3-1.2004.0
       - name: Cache R packages
         uses: actions/cache@v2
         id: cacherenv

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,18 @@ RUN apt update && apt install -y \
     libmysqlclient-dev \
     libglpk40 \
     mysql-server
+# required to install R qgraph package
+RUN apt-get update && apt-get install -y \ 
+    make \
+    g++ \
+    gfortran \
+    libblas-dev \
+    liblapack-dev
 RUN apt-get update && apt-get install -y gnupg
 RUN apt-get update && apt-get install -y software-properties-common
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
 RUN add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/'
-RUN apt update && apt install -y r-base
+RUN apt update && apt install -y --allow-downgrades r-base-core=4.2.3-1.2004.0
 RUN apt install -y pandoc
 RUN apt install -y git
 RUN apt-get update && apt-get install -y vim

--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -72,7 +72,7 @@ You can install RAPIDS using Docker (the fastest), or native instructions for Ma
         brew services start mysql
         ```
 
-    3.  Install R 4.0, pandoc and rmarkdown. If you have other instances of R, we recommend uninstalling them
+    3.  Install R 4.2, pandoc and rmarkdown. If you have other instances of R, we recommend uninstalling them
 
         ``` bash
         brew install r
@@ -162,11 +162,11 @@ You can install RAPIDS using Docker (the fastest), or native instructions for Ma
             sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/'
             ```
 
-    5. Install R 4.0. If you have other instances of R, we recommend uninstalling them
+    5. Install R 4.2. If you have other instances of R, we recommend uninstalling them. Note you may need to include the `-y --allow-downgrades` flags in order to install this R version; please use with caution
 
         ``` bash
         sudo apt update
-        sudo apt install r-base
+        sudo apt install r-base-core=4.2.3-1.2004.0
         ```
 
     6.  Install Pandoc and rmarkdown


### PR DESCRIPTION
Currently, we do not specify which version of R to install in our [tests workflow](https://github.com/carissalow/rapids/blob/a353e58c569f7b9515900337acf80cfcb1e2f7f3/.github/workflows/tests.yaml#L33) or in our [Dockerfile](https://github.com/carissalow/rapids/blob/a353e58c569f7b9515900337acf80cfcb1e2f7f3/Dockerfile#L15), which results in the latest version available being installed. This has apparently not been an issue up to this point. However, the latest version of R available is now R 4.3, which is not compatible with some of the package versions in our R environment.  

Until we upgrade our R environment to be compatible with R 4.3, we can make the following changes:  
- Specify that R version 4.2.3 be installed in our tests workflow  
- Specify that R version 4.2.3 be installed when the RAPIDS Docker image is built from our Dockerfile. We also explicitly install `make`, `g++`, `gfortran`, `BLAS`, and `LAPACK` dependencies so that R package `qgraph` can be installed; otherwise, attempting to build the image locally on both macOS Monterey 12.4 (Docker version 20.10.17) and Ubuntu 20.04 (Docker version 20.10.24) fails at this step  