### PR TITLE
Fix negative battery consumption rate bug

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -1,12 +1,14 @@
 # Change Log
 
-## v1.10.0  
+## v1.9.4  
 
+- Fix bug in PHONE_BATTERY RAPIDS provider that could result in negative values for battery consumption rate features
 - Fix bug in PHONE_APPLICATIONS_FOREGROUND RAPIDS provider that could result in some rows being excluded from output depending on order in which apps are processed   
 - Fix bug in PHONE_SCREEN RAPIDS provider that dropped rows exceeding specified thresholds based on within-segment rather than overall episode duration  
 - Add mutation script to fix character encoding of bt_name column in phone Bluetooth data  
 - Add mutation script to fix character encoding of package_name, before_text, and current_text columns in phone keyboard data   
-- Update documentation for Docker and Ubuntu installation  
+- Specify that R version 4.2.3 be installed in tests workflow and Dockerfile
+- Update documentation for Docker, Mac and Ubuntu installation  
 
 ## v1.9.3
 

--- a/src/features/phone_battery/rapids/main.py
+++ b/src/features/phone_battery/rapids/main.py
@@ -17,9 +17,14 @@ def rapids_features(sensor_data_files, time_segment, provider, filter_data_by_se
 
         if not battery_data.empty:
         
-            battery_data["episode_id"] = ((battery_data.battery_status != battery_data.battery_status.shift()) | (battery_data.start_timestamp - battery_data.end_timestamp.shift() > 1)).cumsum()
+            battery_data["episode_id"] = (
+                (battery_data.battery_status != battery_data.battery_status.shift()) | 
+                (battery_data.start_timestamp - battery_data.end_timestamp.shift() > 1) | 
+                ((battery_data.battery_status.isin([3, 4])) & (battery_data.battery_level > battery_data.battery_level.shift()))
+            ).cumsum()
+
             grouped = battery_data.groupby(by=["local_segment", "episode_id", "battery_status"])
-            battery_episodes= grouped[["duration"]].sum()
+            battery_episodes = grouped[["duration"]].sum()
             battery_episodes["battery_diff"] = grouped["battery_level"].first() - grouped["battery_level"].last()
             battery_episodes["battery_consumption_rate"] = battery_episodes["battery_diff"] / battery_episodes["duration"]
             battery_episodes.reset_index(inplace=True)


### PR DESCRIPTION
This PR addresses an issue that resulted in negative values for battery consumption rate features in the phone battery RAPIDS provider.  

For each battery episode, the battery difference is calculated as the battery level at the end of the episode subtracted from the battery level at the beginning of the episode. Battery consumption rate is then calculated as the ratio between the episode’s battery difference and the duration of the episode. 

Although we calculate a battery consumption rate for all episodes regardless of type, only discharge episodes contribute to computation of the `avgbatteryconsumptionrate` and `maxbatteryconsumptionrate` features. We define discharge episodes as episodes with a battery status of 3 or 4. During a discharge episode, we would expect the battery level at the beginning of the episode to always be greater than or equal to the battery level at the end of the episode (i.e., the battery does not accumulate charge if it is discharging, but may not necessarily lose charge), so we would expect these features to always have a value $\ge$ 0.  

Presently we assign rows of battery data to episodes by incrementing an ID column by 1 when either of the following conditions are met: 
1. The current row’s battery status is not equal to the previous row’s battery status, OR 
2. The time difference between the current row’s start timestamp and the previous row’s end timestamp is >1 ms 

However, there are sometimes cases when the current row's battery status is equal to the previous row’s battery status and that status is 3 or 4 (reflecting discharging), but the current row's battery level is *greater than* the previous row’s battery status (i.e., the battery level increased but there was no corresponding change in battery status to reflect this). Presently such rows would be assigned to the same discharge episode (assuming the time difference criterion is also met), and the resulting battery difference and consumption rate for that discharge episode will be <0. 

To account for this scenario, we include an additional condition when assigning rows of battery data to episodes: 
1. The current row’s battery status is not equal to the previous row’s battery status, OR 
2. The time difference between the current row’s start timestamp and the previous row’s end timestamp is >1 ms, OR
3. **The current row’s battery status is 3 or 4 AND the current row’s battery level is greater than the previous row’s battery level**   


