### PR TITLE
Fix bug in process_location_types.R script

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -2,6 +2,7 @@
 
 ## v1.9.4  
 
+- Fix bug in process_location_types.R script that allowed for <1 minute time differences between a final resampled row and the next sensed location row   
 - Fix bug in PHONE_BATTERY RAPIDS provider that could result in negative values for battery consumption rate features
 - Fix bug in PHONE_APPLICATIONS_FOREGROUND RAPIDS provider that could result in some rows being excluded from output depending on order in which apps are processed   
 - Fix bug in PHONE_SCREEN RAPIDS provider that dropped rows exceeding specified thresholds based on within-segment rather than overall episode duration  

--- a/src/data/process_location_types.R
+++ b/src/data/process_location_types.R
@@ -71,6 +71,8 @@ if(locations_to_use == "ALL"){
                     id = id -1,
                     timestamp = timestamp + (id * 60000)) %>% 
             ungroup() %>% 
+            # drop last resampled row from a group if there is not at least 1 minute between its timestamp and the following sensed location timestamp
+            filter(!(provider == "resampled" & !is.na(lead(timestamp)) & lead(timestamp) - timestamp < 60000)) %>%
             select(-resample_group, -limit, -id)
     } else {
         processed_locations <- locations


### PR DESCRIPTION
We resample a row of location data forward in time into the next minute bin [until](https://github.com/carissalow/rapids/blob/a353e58c569f7b9515900337acf80cfcb1e2f7f3/src/data/process_location_types.R#L65C15-L65C15) 1 ms before the next sensed location timestamp or the timestamp corresponding to last sensed timestamp plus the consecutive threshold buffer is reached, whichever comes first. This can result in time differences <1 minute (60000 ms), and as small as a few ms, between a final resampled row and the subsequent sensed location row:  

| resample_group | limit | timestamp | provider | id | diff_bw_curr_and_next_row_ms |
| -------------- | ----- | --------- | ---------| -- | ---------------------------- |
| 830 | 1660842237896 | 1660842117894 | fused | 0 | 60000 |
| 830 | 1660842237896 | 1660842177894 | resampled | 1 | 60000 |
| 830 | 1660842237896 | 1660842237894 | resampled | 2 | 3 |
| 831 | 1660842357892 | 1660842237897 | fused | 0 | 60000 |
| 831 | 1660842357892 | 1660842297897 | resampled | 1 | 59996 |
| 832 | 1660842477893 | 1660842357893 | fused | 0 | 60000 |
| 832 | 1660842477893 | 1660842417893 | resampled | 1 | 60001 |   

<br>

The inclusion of such rows in the processed locations data can result in unexpected negative values for features like [`varspeed`](https://github.com/carissalow/rapids/blob/a353e58c569f7b9515900337acf80cfcb1e2f7f3/src/features/phone_locations/doryab/main.py#L55C22-L55C22) (which should always be non-negative) in processed data from the PHONE_LOCATIONS DORYAB provider downstream. 

We therefore add a condition to drop rows from the processed locations data when the provider is `resampled` and the difference between that resampled row's timestamp and the next (leading) timestamp is <60000 ms:  

| resample_group | limit | timestamp | provider | id |  diff_bw_curr_and_next_row_ms |
| -------------- | ----- | --------- | ---------| -- | ---------------------------- |
| 830 | 1660842237896 | 1660842117894 | fused | 0 | 60000 |
| 830 | 1660842237896 | 1660842177894 | resampled | 1 | 60003 |
| 831 | 1660842357892 | 1660842237897 | fused | 0 | 119996 |
| 832 | 1660842477893 | 1660842357893 | fused | 0 | 60000 |
| 832 | 1660842477893 | 1660842417893 | resampled | 1 | 60001 |   

<br>

Note that this change still allows for the time difference between two sensed location timestamps to be <60000 ms. It only ensures that the time difference between a resampled timestamp and subsequent sensed location timestamp will be $\ge$ 60000 ms. The time difference between a sensed location timestamp and subsequent resampled timestamp or between two consecutive resampled timestamps is always exactly 60000 ms.  