### PR TITLE
Update Docker installation instructions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,13 +12,13 @@ RAPIDS is open source, documented, multi-platform, modular, tested, and reproduc
 
     :material-github: Bugs should be reported on [Github issues](https://github.com/carissalow/rapids/issues)
 
-    :fontawesome-solid-tasks: Questions, discussions, feature requests, and feedback can be posted on our [Github discussions](https://github.com/carissalow/rapids/discussions)
+    :fontawesome-solid-list-check: Questions, discussions, feature requests, and feedback can be posted on our [Github discussions](https://github.com/carissalow/rapids/discussions)
 
     :material-twitter: Keep up to date with our [Twitter feed](https://twitter.com/RAPIDS_Science) or [Slack channel](http://awareframework.com:3000/)
 
     :material-plus-network: Do you want to modify or add new functionality to RAPIDS? Check our [contributing guide](./contributing)
 
-    :fontawesome-solid-sync-alt: Are you upgrading from RAPIDS `0.4.x` or older? Follow this [guide](migrating-from-old-versions)
+    :fontawesome-solid-rotate: Are you upgrading from RAPIDS `0.4.x` or older? Follow this [guide](migrating-from-old-versions)
 
 
 ## What are the benefits of using RAPIDS?

--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -11,6 +11,10 @@ You can install RAPIDS using Docker (the fastest), or native instructions for Ma
         docker pull moshiresearch/rapids:latest
         ```
 
+        !!! note
+            On M1 and M2 chip Macs, you may need to use the following command to pull the RAPIDS container:  
+            `docker pull --platform linux/x86_64 moshiresearch/rapids:latest`
+
     3.  Run RAPIDS\' container (after this step is done you should see a
         prompt in the main RAPIDS folder with its python environment active)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,8 @@ markdown_extensions:
     - pymdownx.superfences
     - pymdownx.snippets:
         check_paths: True
-    - pymdownx.tabbed
+    - pymdownx.tabbed:
+        alternate_style: True
     - pymdownx.tasklist:
         custom_checkbox: True
     - pymdownx.tilde


### PR DESCRIPTION
This PR includes a couple small updates to our documentation:  
- Updates Docker installation instructions for M1 and M2 chip Macs    
- Fixes broken content tabs and missing Font Awesome icons that had resulted from upgrading Material theme for MkDocs    