### PR TITLE
Workflow update - Fix error

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,7 +29,13 @@ jobs:
       - if: startsWith(github.ref, 'refs/tags')
         run: mike deploy --push --update-aliases $DOCS_TAG latest
       - if: ${{ github.ref == 'refs/heads/develop' }}
-        run: mike deploy --push --update-aliases dev
+        run: |
+          mike deploy --push --update-aliases dev
+          mike alias latest $DOCS_TAG --push  # Update 'latest' to new stable version
+      - if: ${{ github.ref == 'refs/heads/develop' }}       # Deploy 'dev' version AND update 'latest' when develop branch is updated
+        run: | #Deploy dev and Update 'latest' to reflect ongoing changes
+          mike deploy --push --update-aliases dev
+          mike alias latest dev --push
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -40,8 +40,9 @@ jobs:
       # Deploy 'dev' and update 'latest' to 'dev' on develop branch updates
       - if: ${{ github.ref == 'refs/heads/develop' }}
         run: |
-          mike list | grep -q '^dev$' || mike deploy --push --update-aliases dev
-          mike alias latest dev --push
+          mike deploy --push dev  # Always redeploy to update docs
+          mike alias latest dev --push  # Ensure 'latest' always follows 'dev'
+
 
 
 env:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -40,8 +40,9 @@ jobs:
       # Deploy 'dev' and update 'latest' to 'dev' on develop branch updates
       - if: ${{ github.ref == 'refs/heads/develop' }}
         run: |
-          mike deploy --push --update-aliases dev
-          mike alias latest dev --push  # Ensure 'latest' always reflects the most recent build
+          mike list | grep -q '^dev$' || mike deploy --push --update-aliases dev
+          mike alias latest dev --push
+
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,33 +9,39 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - if: ${{ github.ref == 'refs/heads/develop' }} #we delay develop because when we release a hotgix (tag + develop push), one of these push will be out of sync
+      - if: ${{ github.ref == 'refs/heads/develop' }} # Delay develop to prevent out-of-sync updates
         uses: jakejarvis/wait-action@master
         with:
           time: '60s'
+
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
+
       - run: pip install git+https://${GH_TOKEN}@github.com/carissalow/mkdocs-material-insiders.git
       - run: pip install mike
+
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
       - run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
+
       - run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - run: echo "DOCS_TAG=$(echo $RELEASE_VERSION | sed -n "s/v\([0-9]\+\.[0-9]\+\).*$/\1/p")" >> $GITHUB_ENV
+
+      # Deploy and update 'latest' on tagged releases
       - if: startsWith(github.ref, 'refs/tags')
-        run: mike deploy --push --update-aliases $DOCS_TAG latest
+        run: |
+          mike deploy --push --update-aliases $DOCS_TAG latest
+
+      # Deploy 'dev' and update 'latest' to 'dev' on develop branch updates
       - if: ${{ github.ref == 'refs/heads/develop' }}
         run: |
           mike deploy --push --update-aliases dev
-          mike alias latest $DOCS_TAG --push  # Update 'latest' to new stable version
-      - if: ${{ github.ref == 'refs/heads/develop' }}       # Deploy 'dev' version AND update 'latest' when develop branch is updated
-        run: | #Deploy dev and Update 'latest' to reflect ongoing changes
-          mike deploy --push --update-aliases dev
-          mike alias latest dev --push
+          mike alias latest dev --push  # Ensure 'latest' always reflects the most recent build
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -8,7 +8,8 @@
 - Update R version, packages, and package versions in `renv.lock`
 - Update deprecated GitHub actions
 - Update installation documentation for Docker, Mac and Ubuntu
-- Fix website issues, including icons, tabs, and URLs
+- Fix website issues, including icons, tabs, and URLs.
+- Add automatic deployment to update website changes on every push.
   
 ## v1.10.0  
 


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to prevent errors caused by redundant aliasing of dev. Previously, the workflow attempted to alias dev even when it already existed, leading to the error.
Changes Made:
- Removed redundant mike deploy --push --update-aliases dev command
- Ensure dev always gets the latest updates and latest stays in sync, preventing alias conflicts.