### PR TITLE
Fix bug in phone locations radius of gyration feature

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v1.10.2 
+
+- Fix bug in phone locations radius of gyration feature that caused weights and data for weighted average to have different dimensions  
+- Update tests and docker workflow runner images from Ubuntu 20.04 to Ubuntu 22.04  
 
 ## v1.10.1
 

--- a/src/features/phone_locations/doryab/main.py
+++ b/src/features/phone_locations/doryab/main.py
@@ -57,18 +57,21 @@ def distance_and_speed_features(moving_data):
     return distance_and_speed
 
 def radius_of_gyration(location_data):
-    
     if location_data.empty:
         return np.nan
 
+    # reset index so that it is unique which ensures weights have same dimension as data for weighted mean
+    location_data_copy = location_data.copy()
+    location_data_copy.reset_index(drop=True, inplace=True)
+
     # define a lambda function to compute the weighted mean for each cluster
-    weighted_mean = lambda x: np.average(x, weights=location_data.loc[x.index, "duration"])
+    weighted_mean = lambda x: np.average(x, weights=location_data_copy.loc[x.index, "duration"])
  
     # center is the centroid of the places visited during a segment instance, not the home location
-    clusters = location_data.groupby(["local_segment", "cluster_label"]).agg(
-        double_latitude=("double_latitude", weighted_mean),
-        double_longitude=("double_longitude", weighted_mean),
-        time_in_a_cluster=("duration", "sum")
+    clusters = location_data_copy.groupby(["local_segment", "cluster_label"]).agg(
+        double_latitude = ("double_latitude", weighted_mean),
+        double_longitude = ("double_longitude", weighted_mean),
+        time_in_a_cluster = ("duration", "sum")
     ).reset_index()
 
     # redefine the lambda function to compute the weighted mean across clusters


### PR DESCRIPTION
When processing phone locations Doryab provider features with the `CLUSTER_ON` parameter set to `TIME_SEGMENT_INSTANCE`, we get the following error when computing the first (within-cluster) weighted mean for the radius of gyration feature:  

`TypeError: Axis must be specified when shapes of a and weights differ.`  

This occurs because the index of the `location_data` dataframe is not unique. When this index is used to extract the weights for the weighted mean for a given segment-cluster group from the location data, this results in the weights and the values to which they should be applied having different dimensions. To fix this, we reset the dataframe index to ensure the index is unique and the weights will have the expected dimensions. 