### PR TITLE
Update workflow runner images to Ubuntu 22.04

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -4,7 +4,7 @@ on:
     types: [edited, released]
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,6 +28,8 @@ jobs:
           # sudo apt install libcurl4-openssl-dev
           # sudo apt install libssl-dev
           # sudo apt install libxml2-dev
+          wget http://archive.ubuntu.com/ubuntu/pool/main/i/icu/libicu66_66.1-2ubuntu2_amd64.deb
+          sudo dpkg -i libicu66_66.1-2ubuntu2_amd64.deb
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
           sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/' 
           sudo apt install -y --allow-downgrades r-base-core=4.2.3-1.2004.0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   test-on-latest-ubuntu:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3 # Updated from v2 to v3
         with:


### PR DESCRIPTION
Our tests and docker workflows are currently configured to run on Ubuntu 20.04 runner images, which as of April 15, 2025, are no longer supported by GitHub Actions (see #241). This PR updates the runner images for these two workflows from Ubuntu 20.04 to Ubuntu 22.04. 

For the tests workflow, we also add a step to manually install the `libicu66` dependency for R. Without this step, R installation fails due to unmet dependencies: 

```
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 r-base-core : Depends: libicu66 (>= 66.1-1~) but it is not installable
               Recommends: r-recommended but it is not going to be installed
               Recommends: r-base-dev but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```