### PR TITLE
Fix bug in cluster_centroids() function

### DIFF
--- a/src/features/phone_locations/doryab/main.py
+++ b/src/features/phone_locations/doryab/main.py
@@ -73,6 +73,13 @@ def cluster_centroids(location_data):
         .reset_index()
     )
 
+    if "index" in centroids.columns:
+        centroids.drop("index", axis=1, inplace=True)
+    if not "local_segment" in centroids.columns:
+        centroids = centroids.assign(local_segment=None)
+    if not "cluster_label" in centroids.columns:
+        centroids = centroids.assign(cluster_label=None)
+
     return centroids
 
 def radius_of_gyration(location_data):


### PR DESCRIPTION
This PR fixes a minor bug that can occur when processing phone locations features with the DORYAB provider. When the stationary data without outliers are empty, we get the following error when attempting to compute the top n significant locations cluster centroid features: `KeyError: 'local_segment'`. This occurs because when the input data for clustering are empty, the output of the `cluster_centroids()` function contains an unexpected "index" column and is missing the expected "local_segment" and "cluster_label" columns. To fix this, we drop the "index" column if present and add the "local_segment" and "cluster_label" columns if missing from the `centroids` dataframe. 
