### PR TITLE
Fix bug parsing raw Fitbit calories JSON data

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -4,6 +4,7 @@
 
 - Add significant location cluster centroid latitude and longitude features to phone locations Doryab provider   
 - Fix bug in phone locations radius of gyration feature that caused weights and data for weighted average to have different dimensions 
+- Fix bug parsing raw Fitbit calories JSON data when records in the intraday dataset are missing level and/or mets elements    
 - Fix typo in name of Fitbit steps intraday RAPIDS provider sumdurationactivity5to10minutes feature that did not affect computation  
 - Change Fitbit JSON MySQL data stream default settings to match PittBit's format  
 - Relocate participant ID column from end to beginning of merged processed feature data  

--- a/src/data/streams/mutations/fitbit/parse_calories_intraday_json.py
+++ b/src/data/streams/mutations/fitbit/parse_calories_intraday_json.py
@@ -12,15 +12,17 @@ def parseCaloriesData(calories_data):
 
     # Parse JSON into individual records
     for record in calories_data.json_fitbit_column:
-        record = json.loads(record)  # Parse text into JSON
+        record = json.loads(record)  
         if "activities-calories" in record and "activities-calories-intraday" in record:
             curr_date = datetime.strptime(record["activities-calories"][0]["dateTime"], "%Y-%m-%d")
             dataset = record["activities-calories-intraday"]["dataset"]
             for data in dataset:
                 d_time = datetime.strptime(data["time"], '%H:%M:%S').time()
                 d_datetime = datetime.combine(curr_date, d_time).strftime("%Y-%m-%d %H:%M:%S")
-                row_intraday = (device_id, data["level"], data["mets"], data["value"], d_datetime, 0)
-                records_intraday.append(row_intraday)
+                # discard minutes that do not contain all expected level, mets, and value elements
+                if all(element in data.keys() for element in ["level", "mets", "value"]):
+                    row_intraday = (device_id, data["level"], data["mets"], data["value"], d_datetime, 0)
+                    records_intraday.append(row_intraday)
 
     return pd.DataFrame(data=records_intraday, columns=CALORIES_INTRADAY_COLUMNS)
 


### PR DESCRIPTION
Every minute-level record in the raw Fitbit `activities-calories-intraday` dataset is [expected](https://dev.fitbit.com/build/reference/web-api/intraday/get-activity-intraday-by-date-range/#Response) to contain `level`, `mets`, `time`, and `value` elements. However, we've found that it's possible for raw intraday calories time series data to contain only `time` and `value` elements. For example: 

```json
"activities-calories-intraday": {
    "dataset": [
      {
        "time": "00:00:00",
        "value": 1.39192
      },
      {
        "time": "00:01:00",
        "value": 1.5311120000000003
      },
    ]
}
```

Currently, parsing raw Fitbit intraday calories JSON data fails with these data specifically, as well as more broadly if `level`, `mets`, and/or `value` elements are not present in at least one minute-level record for a participant. To fix this, before parsing each minute-level record into a row of data, we first check if the record contains all expected elements instead of assuming they are present. If one or more expected elements are missing, that minute-level record is discarded. If all minute-level records within an intraday dataset are missing one or more expected elements, this has the effect of discarding the entire day of data. Downstream, Fitbit intraday calories features are computed only from "complete" minutes of data. 