### PR TITLE
Fix bug parsing raw Fitbit sleep intraday JSON data

### DIFF
--- a/src/data/streams/mutations/fitbit/parse_sleep_intraday_json.py
+++ b/src/data/streams/mutations/fitbit/parse_sleep_intraday_json.py
@@ -4,135 +4,154 @@ import numpy as np
 from datetime import datetime, timedelta
 import dateutil.parser
 
-SLEEP_CODE2LEVEL = ["asleep", "restless", "awake"]
+SLEEP_CODE_TO_LEVEL = {
+    1: "asleep", 
+    2: "restless", 
+    3: "awake"
+}
 
-SLEEP_INTRADAY_COLUMNS = ("device_id",
-                            "type_episode_id",
-                            "duration",
-                            # For "classic" type, original_level is one of {"awake", "restless", "asleep"}
-                            # For "stages" type, original_level is one of {"wake", "deep", "light", "rem"}
-                            "level",
-                            # one of {0, 1} where 0: nap, 1: main sleep
-                            "is_main_sleep", 
-                            # one of {"classic", "stages"}
-                            "type",
-                            "local_date_time",
-                            "timestamp")
+SLEEP_INTRADAY_COLUMNS = [
+    "device_id",
+    "type_episode_id",
+    "duration",
+    "level",            # for "classic" type, one of {"awake", "restless", "asleep"}; for "stages" type, one of {"wake", "deep", "light", "rem"}
+    "is_main_sleep",    # one of {0, 1} where 0: nap, 1: main sleep
+    "type",             # one of {"classic", "stages"}
+    "local_date_time",
+    "timestamp"
+]
 
-def mergeLongAndShortData(data_intraday):
-    long_data = pd.DataFrame(columns=["dateTime", "level"])
-    short_data = pd.DataFrame(columns=["dateTime", "level"])
+def resampleLevelsData(levels_data, element):
+    if not element in ["data", "shortData"]:
+        raise ValueError(f"Unrecognized levels element: {element}")
 
     window_length = 30
+    resampled_data = []
 
-    for data in data_intraday["data"]:
-        counter = 0
-        for times in range(data["seconds"] // window_length):
-            row = {"dateTime": dateutil.parser.parse(data["dateTime"])+timedelta(seconds=counter*window_length), "level": data["level"]}
-            long_data = long_data.append(row, ignore_index = True)
-            counter = counter + 1
+    for data in levels_data[element]:
+        for i in range(data["seconds"] // window_length):
+            row = {
+                "dateTime": dateutil.parser.parse(data["dateTime"]) + timedelta(seconds=i*window_length), 
+                "level": data["level"]
+            }
+            resampled_data.append(row)
 
-    for data in data_intraday["shortData"]:
-        counter = 0
-        for times in range(data["seconds"] // window_length):
-            row = {"dateTime": dateutil.parser.parse(data["dateTime"])+timedelta(seconds=counter*window_length), "level": data["level"]}
-            short_data = short_data.append(row, ignore_index = True)
-            counter = counter + 1
-    long_data.set_index("dateTime",inplace=True)
-    short_data.set_index("dateTime",inplace=True)
-    long_data["level"] = np.where(long_data.index.isin(short_data.index) == True, "wake", long_data["level"])
-    
+    resampled_data = pd.DataFrame(resampled_data, columns=["dateTime", "level"]).set_index("dateTime")
+    return resampled_data
+
+
+def mergeLongAndShortLevelsData(levels_data):
+    long_data = resampleLevelsData(levels_data, "data")
+
+    if "shortData" in levels_data:
+        short_data = resampleLevelsData(levels_data, "shortData")
+        long_data["level"] = np.where(long_data.index.isin(short_data.index), "wake", long_data["level"])
+
     long_data.reset_index(inplace=True)
-    
     return long_data.values.tolist()
 
-# Parse one record for sleep API version 1
-def parseOneRecordForV1(record, device_id, d_is_main_sleep, records_intraday, type_episode_id):
 
+def parseOneRecordForV1(record, is_main_sleep, records_intraday, type_episode_id):
     sleep_record_type = "classic"
+    duration = 60
+    timestamp = 0
 
     d_start_datetime = datetime.strptime(record["startTime"][:18], "%Y-%m-%dT%H:%M:%S")
     d_end_datetime = datetime.strptime(record["endTime"][:18], "%Y-%m-%dT%H:%M:%S")
 
-    # Intraday data
     start_date = d_start_datetime.date()
     end_date = d_end_datetime.date()
     is_before_midnight = True
     curr_date = start_date
+
     for data in record["minuteData"]:
         # For overnight episodes, use end_date once we are over midnight
-        d_time = datetime.strptime(data["dateTime"], '%H:%M:%S').time()
+        d_time = datetime.strptime(data["dateTime"], "%H:%M:%S").time()
         if is_before_midnight and d_time.hour == 0:
             curr_date = end_date
+        
         d_datetime = datetime.combine(curr_date, d_time).strftime("%Y-%m-%d %H:%M:%S")
+        d_original_level = SLEEP_CODE_TO_LEVEL[int(data["value"])]
 
-        # API 1.2 stores original_level as strings, so we convert original_levels of API 1 to strings too
-        # (1: "asleep", 2: "restless", 3: "awake")
-        d_original_level = SLEEP_CODE2LEVEL[int(data["value"])-1]
-
-
-        row_intraday = (device_id, type_episode_id, 60,
-                        d_original_level, d_is_main_sleep, sleep_record_type,
-                        d_datetime, 0)
-
+        row_intraday = {
+            "type_episode_id": type_episode_id,
+            "duration": duration,
+            "level": d_original_level,           
+            "is_main_sleep": is_main_sleep,   
+            "type": sleep_record_type,             
+            "local_date_time": d_datetime,
+            "timestamp": timestamp
+        }
         records_intraday.append(row_intraday)
 
     return records_intraday
 
-# Parse one record for sleep API version 1.2
-def parseOneRecordForV12(record, device_id, d_is_main_sleep, records_intraday, type_episode_id):
-    
-    sleep_record_type = record['type']
+
+def parseOneRecordForV12(record, is_main_sleep, records_intraday, type_episode_id):
+    stages_duration = 30
+    timestamp = 0
+
+    sleep_record_type = record["type"]
 
     if sleep_record_type == "classic":
         for data in record["levels"]["data"]:
             d_datetime = data["dateTime"][:19].replace("T", " ")
-
-            row_intraday = (device_id, type_episode_id, data["seconds"],
-                data["level"], d_is_main_sleep, sleep_record_type,
-                d_datetime, 0)
-            records_intraday.append(row_intraday)
-    else:
-        # For sleep type "stages"
-        for data in mergeLongAndShortData(record["levels"]):
-            d_datetime = data[0].strftime("%Y-%m-%d %H:%M:%S")
-            row_intraday = (device_id, type_episode_id, 30,
-                data[1], d_is_main_sleep, sleep_record_type,
-                d_datetime, 0)
-
+            row_intraday = {
+                "type_episode_id": type_episode_id,
+                "duration": data["seconds"],
+                "level": data["level"],           
+                "is_main_sleep": is_main_sleep,   
+                "type": sleep_record_type,             
+                "local_date_time": d_datetime,
+                "timestamp": timestamp
+            }
             records_intraday.append(row_intraday)
     
+    elif sleep_record_type == "stages":
+        for data in mergeLongAndShortLevelsData(record["levels"]):
+            d_datetime = data[0].strftime("%Y-%m-%d %H:%M:%S")
+            row_intraday = {
+                "type_episode_id": type_episode_id,
+                "duration": stages_duration,
+                "level": data[1],           
+                "is_main_sleep": is_main_sleep,   
+                "type": sleep_record_type,             
+                "local_date_time": d_datetime,
+                "timestamp": timestamp
+            }
+            records_intraday.append(row_intraday)
+    
+    else:
+        raise ValueError(f"Unrecognized sleep record type: {sleep_record_type}")
+
     return records_intraday
     
-
 
 def parseSleepData(sleep_data):
     if sleep_data.empty:
         return pd.DataFrame(columns=SLEEP_INTRADAY_COLUMNS)
+
     device_id = sleep_data["device_id"].iloc[0]
     records_intraday = []
     type_episode_id = 0
-    # Parse JSON into individual records
+
     for multi_record in sleep_data.json_fitbit_column:
         sleep_record = json.loads(multi_record)
         if "sleep" in sleep_record:
-            for record in json.loads(multi_record)["sleep"]:
-                # Whether the sleep episode is nap (0) or main sleep (1)
-                d_is_main_sleep = 1 if record["isMainSleep"] else 0
+            for record in sleep_record["sleep"]:
+                is_main_sleep = 1 if record["isMainSleep"] else 0
 
-                # For sleep API version 1
-                if "awakeCount" in record:
-                    records_intraday = parseOneRecordForV1(record, device_id, d_is_main_sleep, records_intraday, type_episode_id)
-                # For sleep API version 1.2
+                if "awakeCount" in record: 
+                    records_intraday = parseOneRecordForV1(record, is_main_sleep, records_intraday, type_episode_id)
                 else:
-                    records_intraday = parseOneRecordForV12(record, device_id, d_is_main_sleep, records_intraday, type_episode_id)
+                    records_intraday = parseOneRecordForV12(record, is_main_sleep, records_intraday, type_episode_id)
                 
-                type_episode_id = type_episode_id + 1
+                type_episode_id += 1
 
-    parsed_data = pd.DataFrame(data=records_intraday, columns=SLEEP_INTRADAY_COLUMNS)
-
+    parsed_data = pd.DataFrame(data=records_intraday)
+    parsed_data.insert(0, column="device_id", value=device_id)
+    
     return parsed_data
-
 
 
 def main(json_raw, stream_parameters):


### PR DESCRIPTION
When a raw JSON Fitbit sleep record has type `stages`, we expect the intraday `levels` element in the sleep record to contain two groupings of data: `data` and `shortData`. Per Fitbit's [documentation](https://dev.fitbit.com/build/reference/web-api/developer-guide/best-practices/#Interpreting-the-Sleep-Stage-and-Short-Data), the `data` grouping contains the sleep stages (rem, light, deep) and any wake periods that were > 3 minutes in duration. The `shortData` grouping contains wake periods that were <= 3 minutes in duration. We merge the sleep stage labels contained in these `data` and `shortData` groupings in the mutation script that handles parsing raw Fitbit sleep intraday JSON data. 

<br>

However, we've encountered a handful of sleep records with type `stages` that inexplicably **do not** contain the expected `shortData` grouping. This does not seem to be related to whether or not the record represents the main sleep episode.  When the `shortData` element is missing, the following error occurs when applying the mutation script: 

```
Error in py_call_impl(callable, dots$args, dots$keywords) : 
  KeyError: 'shortData'

Detailed traceback: 
  File "/rapids/src/data/streams/mutations/fitbit/parse_sleep_intraday_json.py", line 139, in main
    parsed_data = parseSleepData(json_raw)
  File "/rapids/src/data/streams/mutations/fitbit/parse_sleep_intraday_json.py", line 128, in parseSleepData
    records_intraday = parseOneRecordForV12(record, device_id, d_is_main_sleep, records_intraday, type_episode_id)
  File "/rapids/src/data/streams/mutations/fitbit/parse_sleep_intraday_json.py", line 97, in parseOneRecordForV12
    for data in mergeLongAndShortData(record["levels"]):
  File "/rapids/src/data/streams/mutations/fitbit/parse_sleep_intraday_json.py", line 35, in mergeLongAndShortData
    for data in data_intraday["shortData"]:
```

<br>
<br>

To fix this, we now first check if the `shortData` element is present in the `levels` data for the record. If so, we resample the `shortData` and merge it with the resampled "long" `data`. Otherwise, we only use the resampled "long" `data`. We also make some modifications to this script to improve efficiency (e.g., appending data to a list and then converting the complete list to a DataFrame rather than appending rows of data directly to a DataFrame) and readability. 