### PR TITLE
Fix missing column when parsed Fitbit sleep intraday data are empty

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -5,6 +5,7 @@
 - Add significant location cluster centroid latitude and longitude features to phone locations Doryab provider   
 - Fix bug in phone locations radius of gyration feature that caused weights and data for weighted average to have different dimensions 
 - Fix bug parsing raw Fitbit calories JSON data when records in the intraday dataset are missing level and/or mets elements    
+- Fix bug parsing raw Fitbit sleep JSON data when a stages record is missing the shortData grouping in the intraday levels dataset
 - Fix typo in name of Fitbit steps intraday RAPIDS provider sumdurationactivity5to10minutes feature that did not affect computation  
 - Change Fitbit JSON MySQL data stream default settings to match PittBit's format  
 - Relocate participant ID column from end to beginning of merged processed feature data  

--- a/src/data/streams/mutations/fitbit/parse_sleep_intraday_json.py
+++ b/src/data/streams/mutations/fitbit/parse_sleep_intraday_json.py
@@ -148,9 +148,8 @@ def parseSleepData(sleep_data):
                 
                 type_episode_id += 1
 
-    parsed_data = pd.DataFrame(data=records_intraday)
-    parsed_data.insert(0, column="device_id", value=device_id)
-    
+    parsed_data = pd.DataFrame(data=records_intraday, columns=SLEEP_INTRADAY_COLUMNS)
+    parsed_data["device_id"] = device_id
     return parsed_data
 
 


### PR DESCRIPTION
Recent changes to the mutation script for parsing raw Fitbit sleep intraday JSON data inadvertently resulted in the "local_date_time" column being excluded from the parsed data when the parsed data were empty. This caused the following error when the mutation script to add zero timestamps was subsequently applied to those data: 

```
Error in py_call_impl(callable, dots$args, dots$keywords) : 
  KeyError: 'local_date_time'

Detailed traceback: 
  File "/rapids/src/data/streams/mutations/fitbit/add_zero_timestamp.py", line 5, in main
    if pd.api.types.is_datetime64_any_dtype(parsed_data['local_date_time']):
```

This PR fixes this issue.